### PR TITLE
Fix invalid positions when seeking w/ click+drag

### DIFF
--- a/src/SimpleVideoCutter/VideoCutterTimeline.cs
+++ b/src/SimpleVideoCutter/VideoCutterTimeline.cs
@@ -406,7 +406,19 @@ namespace SimpleVideoCutter
         {
             if (Length == 0)
                 return 0;
-            return (long)(offset + x * MillisecondsPerPixels(givenScale));
+
+            long pos = (long)(offset + x * MillisecondsPerPixels(givenScale));
+
+            // Do not allow negative starting position
+            if (pos < 0) {
+                pos = 0;
+            }
+            // Do not exceed total video length
+            if (pos > Length) {
+                pos = Length;
+            }
+            
+            return pos;
         }
 
         public void ZoomOut()


### PR DESCRIPTION
Hey bartekmotyl,

I stumbled upon an error when using click and drag to move the selection cursor on the timeline, that you may end up having negative positions or positions that exceed the total video length. 

_Example_: Trying to move the selector to the zero-position using clicking-and-dragging but overshooting the exact pixel of 00:00:00 results in a negative timestamp and thus impacts the cutting result.
![Timeline](https://i.imgur.com/HGeUaQ5.png)

The same behaviour can be observed when overshooting the end-position and this pull request fixes it 🙂 

Best regards,
Thomas