### PR TITLE
Improvements for german translation

### DIFF
--- a/src/SimpleVideoCutter/AboutBox.de.resx
+++ b/src/SimpleVideoCutter/AboutBox.de.resx
@@ -121,10 +121,10 @@
     <value>Name des Produkts</value>
   </data>
   <data name="labelVersion.Text" xml:space="preserve">
-    <value>Fassung</value>
+    <value>Version</value>
   </data>
   <data name="labelCopyright.Text" xml:space="preserve">
-    <value>Urheberrecht</value>
+    <value>Copyright</value>
   </data>
   <data name="okButton.Text" xml:space="preserve">
     <value>OK</value>
@@ -132,7 +132,7 @@
   <data name="textBox1.Text" xml:space="preserve">
     <value>Symbole: streamlineicons.com
 FFmpeg: www.ffmpeg.org
-Foto von Denise Jans zur Entblößung</value>
+Foto von Denise Jans via Unsplash</value>
   </data>
   <data name="buttonLicense.Text" xml:space="preserve">
     <value>Lizenz</value>

--- a/src/SimpleVideoCutter/FormAddTask.de.resx
+++ b/src/SimpleVideoCutter/FormAddTask.de.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="buttonSaveProfile.Size" type="System.Drawing.Size, System.Drawing">
+    <value>180, 23</value>
+  </data> 
   <data name="buttonSaveProfile.Text" xml:space="preserve">
     <value>Profil erstellen oder aktualisieren</value>
   </data>

--- a/src/SimpleVideoCutter/FormFFmpegMissingDialog.de.resx
+++ b/src/SimpleVideoCutter/FormFFmpegMissingDialog.de.resx
@@ -125,7 +125,7 @@
   </data>
   <data name="labelFFmpegExlanation.Text" xml:space="preserve">
     <value>Dieses Programm setzt voraus, dass FFmpeg in Ihrem System installiert ist. FFmpeg ist eine kostenlose, quelloffene Lösung zur Konvertierung von Videodateien.
-Bitte besuchen Sie die unten verlinkte Seite, laden Sie die portable Distribution herunter und entpacken Sie sie auf die lokale Festplatte. Release, statische 64bit-Version wird empfohlen.
+Bitte besuchen Sie die oben verlinkte Seite, laden Sie die portable Distribution herunter und entpacken Sie sie auf die lokale Festplatte. Release, statische 64bit-Version wird empfohlen.
 Sobald FFmpeg installiert ist, geben Sie bitte den Pfad zur ausführbaren Datei ffmpeg im Einstellungsfenster an.</value>
   </data>
   <data name="buttonDownload.Text" xml:space="preserve">

--- a/src/SimpleVideoCutter/FormSettings.de.resx
+++ b/src/SimpleVideoCutter/FormSettings.de.resx
@@ -133,12 +133,12 @@
     <value>ffmpeg.exe Pfad:</value>
   </data>
   <data name="textBoxVideoFileExtensions.ToolTip" xml:space="preserve">
-    <value>Komma getrennte Liste von Erweiterungen (mit Punkt)
+    <value>Kommagetrennte Liste von Erweiterungen (mit Punkt)
 der zu berücksichtigenden Videodateien. Wichtig bei
 zur vorherigen/nächsten Videodatei im Verzeichnis navigieren.</value>
   </data>
   <data name="label5.Text" xml:space="preserve">
-    <value>Erweiterungen von Videodateien:</value>
+    <value>Videodatei-Erweiterungen:</value>
   </data>
   <data name="buttonCancel.Text" xml:space="preserve">
     <value>Abbrechen</value>
@@ -148,5 +148,23 @@ zur vorherigen/nächsten Videodatei im Verzeichnis navigieren.</value>
   </data>
   <data name="buttonOK.Text" xml:space="preserve">
     <value>OK</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>560, 212</value>
+  </data> 
+  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>150, 23</value>
+  </data>
+  <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>150, 23</value>
+  </data>
+  <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>150, 23</value>
+  </data>
+  <data name="label4.Size" type="System.Drawing.Size, System.Drawing">
+    <value>150, 23</value>
+  </data>
+  <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
+    <value>150, 23</value>
   </data>
 </root>

--- a/src/SimpleVideoCutter/MainForm.de.resx
+++ b/src/SimpleVideoCutter/MainForm.de.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="toolStripStatusLabelVolume.Text" xml:space="preserve">
-    <value>Umfang: 100 %</value>
+    <value>Laustärke: 100 %</value>
   </data>
   <data name="toolStripStatusLabelFilePath.Text" xml:space="preserve">
     <value>Keine Datei geladen</value>
@@ -130,7 +130,7 @@
     <value>Keine Auswahl</value>
   </data>
   <data name="columnStatus.Text" xml:space="preserve">
-    <value>Stand</value>
+    <value>Status</value>
   </data>
   <data name="columnProfile.Text" xml:space="preserve">
     <value>Profil</value>
@@ -232,7 +232,7 @@
     <value>Über</value>
   </data>
   <data name="toolStripMenuItemLangGerman.Text" xml:space="preserve">
-    <value>Deutsch (maschinelle Übersetzung)</value>
+    <value>Deutsch</value>
   </data>
   <data name="toolStripMenuItemLangFrench.Text" xml:space="preserve">
     <value>Französisch (maschinelle Übersetzung)</value>

--- a/src/SimpleVideoCutter/MainForm.es.resx
+++ b/src/SimpleVideoCutter/MainForm.es.resx
@@ -232,7 +232,7 @@
     <value>Acerca de</value>
   </data>
   <data name="toolStripMenuItemLangGerman.Text" xml:space="preserve">
-    <value>Alemán (traducción automática)</value>
+    <value>Alemán</value>
   </data>
   <data name="toolStripMenuItemLangFrench.Text" xml:space="preserve">
     <value>Francés (traducción automática)</value>

--- a/src/SimpleVideoCutter/MainForm.fr.resx
+++ b/src/SimpleVideoCutter/MainForm.fr.resx
@@ -232,7 +232,7 @@
     <value>À propos de</value>
   </data>
   <data name="toolStripMenuItemLangGerman.Text" xml:space="preserve">
-    <value>Allemand (traduction automatique)</value>
+    <value>Allemand</value>
   </data>
   <data name="toolStripMenuItemLangFrench.Text" xml:space="preserve">
     <value>Français (traduction automatique)</value>

--- a/src/SimpleVideoCutter/MainForm.it.resx
+++ b/src/SimpleVideoCutter/MainForm.it.resx
@@ -232,7 +232,7 @@
     <value>Informazioni su</value>
   </data>
   <data name="toolStripMenuItemLangGerman.Text" xml:space="preserve">
-    <value>Tedesco (traduzione automatica)</value>
+    <value>Tedesco</value>
   </data>
   <data name="toolStripMenuItemLangFrench.Text" xml:space="preserve">
     <value>Francese (traduzione automatica)</value>

--- a/src/SimpleVideoCutter/MainForm.pl.resx
+++ b/src/SimpleVideoCutter/MainForm.pl.resx
@@ -277,7 +277,7 @@ powiększenie</value>
     <value>Przewiń oś czasu do aktualnej pozycji (Ctrl+P)</value>
   </data>
   <data name="toolStripMenuItemLangGerman.Text" xml:space="preserve">
-    <value>Niemiecki (tłumaczenie maszynowe)</value>
+    <value>Niemiecki</value>
   </data>
   <data name="toolStripMenuItemLangFrench.Text" xml:space="preserve">
     <value>Francuski (tłumaczenie maszynowe)</value>

--- a/src/SimpleVideoCutter/MainForm.resx
+++ b/src/SimpleVideoCutter/MainForm.resx
@@ -1114,7 +1114,7 @@ Press also Shift to set selection from the beginning till this point.</value>
     <value>237, 22</value>
   </data>
   <data name="toolStripMenuItemLangGerman.Text" xml:space="preserve">
-    <value>German (machine translation)</value>
+    <value>German</value>
   </data>
   <data name="toolStripMenuItemLangFrench.Size" type="System.Drawing.Size, System.Drawing">
     <value>237, 22</value>

--- a/src/SimpleVideoCutter/Properties/GlobalStrings.de.resx
+++ b/src/SimpleVideoCutter/Properties/GlobalStrings.de.resx
@@ -189,7 +189,7 @@ Erlaubt sind sowohl statische Teile als auch diese Pseudo-Variablen
     <value>Auswahl</value>
   </data>
   <data name="MainForm_Volume" xml:space="preserve">
-    <value>Jahrgang</value>
+    <value>Lautstärke</value>
   </data>
   <data name="TaskProcessor_Done" xml:space="preserve">
     <value>Erledigt</value>

--- a/src/SimpleVideoCutter/Properties/GlobalStrings.de.resx
+++ b/src/SimpleVideoCutter/Properties/GlobalStrings.de.resx
@@ -124,7 +124,7 @@
     <value>Neue Version ist verfügbar! Bitte besuchen Sie die Projektseite.</value>
   </data>
   <data name="AboutBox_Version" xml:space="preserve">
-    <value>Fassung</value>
+    <value>Version</value>
   </data>
   <data name="AboutBox_VersionUpToDate" xml:space="preserve">
     <value>Sie verwenden die neueste Version.</value>


### PR DESCRIPTION
Hey bartekmotyl,

I have done several improvements to the german translation. The pull-request includes:

- Correction for some mistranslated/unnecessarily translated words (from the machine translation)
- Adjustments to some element-widths (labels, buttons, frames) to avoid clipping of the contents (only on the german translation)
- Removal of the "(machine translated)" for the menuitem for "German" in all languages

Best regards,
Thomas