### PR TITLE
Support for Multiple Audio Track Support (Feature request #20)

### DIFF
--- a/src/SimpleVideoCutter/FFmpegNET/FFmpegArgumentBuilder.cs
+++ b/src/SimpleVideoCutter/FFmpegNET/FFmpegArgumentBuilder.cs
@@ -19,6 +19,7 @@ namespace SimpleVideoCutter.FFmpegNET
             commandBuilder.AppendFormat(CultureInfo.InvariantCulture, " -ss {0} ", seek);
             commandBuilder.AppendFormat(" -t {0} ", duration);
             commandBuilder.AppendFormat(" -i \"{0}\" ", inputFileFullPath);
+            commandBuilder.AppendFormat(" -map 0 ");
             commandBuilder.AppendFormat(" {0}", customArguments);
             
             return commandBuilder.AppendFormat(" \"{0}\" ", outputFileFullPath).ToString();


### PR DESCRIPTION
Hey bartekmotyl,

I have solved the feature request #20 by always selecting all audio streams (using the additional argument "-map 0", as documented in https://trac.ffmpeg.org/wiki/Map )

Best regards,
Thomas